### PR TITLE
Added docker setup for YARN resourcemanager and nodemanager services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+hadoop/hadoop-conf/SNAPSHOT/*SNAPSHOT.tar.gz
+*SNAPSHOT.tar.gz
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Use Ubuntu as the base image
+FROM ubuntu:20.04
+
+# Install necessary packages
+RUN apt-get update && apt-get install -y \
+    openjdk-8-jdk \
+    ssh \
+    rsync \
+    curl \
+    net-tools
+
+# Add hadoop user
+RUN useradd -m hadoop
+
+# Set JAVA_HOME environment variable
+# ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64
+ENV PATH=$PATH:$JAVA_HOME/bin
+
+# Set Hadoop environment variables for YARN users
+ENV YARN_RESOURCEMANAGER_USER=hadoop
+ENV YARN_NODEMANAGER_USER=hadoop
+ENV YARN_PROXYSERVER_USER=hadoop
+
+# Copy Hadoop binaries from the host machine (the snapshot)
+RUN rm -rf /usr/local; mkdir -p /usr/local
+RUN rm -rf /usr/local/hadoop
+COPY hadoop/SNAPSHOT/hadoop-*-SNAPSHOT.tar.gz /usr/local/hadoop.tar.gz
+# Extract the binaries
+RUN tar -xzf /usr/local/hadoop.tar.gz -C /usr/local/ && filename=$(ls /usr/local/ | grep -i hadoop | grep -i snapshot | head -n1) && ln -s "/usr/local/$filename" /usr/local/hadoop
+
+# Set Hadoop environment variables
+ENV HADOOP_HOME=/usr/local/hadoop
+ENV HADOOP_CONF_DIR=$HADOOP_HOME/etc/hadoop
+ENV PATH=$PATH:$HADOOP_HOME/bin:$HADOOP_HOME/sbin
+
+# Copy Hadoop configuration files
+COPY hadoop/hadoop-conf/* $HADOOP_CONF_DIR/
+RUN mkdir -p /usr/local/hadoop/logs && chown -R hadoop:hadoop /usr/local/hadoop*
+
+# Format HDFS namenode
+RUN $HADOOP_HOME/bin/hdfs namenode -format
+
+# Expose ports for Hadoop services (UI, ResourceManager, NodeManagers)
+EXPOSE 8088 8042 50070 50075
+
+# Default command to keep the container running
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,71 @@
-# hadoop-yarn-docker
-Repository for provisioning a YARN ResourceManager cluster on Docker for quick validation and testing. Easily set up and run a YARN cluster in a containerized environment for development, troubleshooting, and rapid experimentation.
+# Hadoop YARN Docker
+Repository for provisioning a YARN ResourceManager cluster on Docker for quick validation and testing. This setup allows you to easily run and manage a YARN cluster in a containerized environment, perfect for development, troubleshooting, and rapid experimentation with Apache Hadoop.
+
+## Prerequisites
+- **Docker**: Ensure Docker is installed and running on your machine.
+- **Docker Compose**: Install Docker Compose for orchestrating multi-container applications.
+- **Maven**: Required for building Hadoop from source.
+- **Hadoop Source Code**: Clone the latest version of Hadoop from the official repository.
+
+## Setup Instructions
+
+### 1. Clone the Hadoop Repository
+First, clone the latest version of Hadoop using Git:
+
+```bash
+git clone https://gitbox.apache.org/repos/asf/hadoop.git
+```
+
+### 2. Build Hadoop from Source
+After making any necessary changes or if you just need to build Hadoop, navigate to the Hadoop root directory and run the following Maven command to build the distribution package:
+```bash
+mvn clean package -Pdist -DskipTests -Dtar
+```
+
+This will create a Hadoop distribution package without running tests, which can then be used to set up your Docker containers.
+
+### 3. Move the Hadoop Distribution to Docker Setup
+Once the build is complete, copy the generated Hadoop distribution snapshot to the `hadoop/SNAPSHOT` directory in this repository:
+```bash
+cp <your-hadoop-repo>/hadoop-dist/target/hadoop-<version>-SNAPSHOT.tar.gz hadoop-yarn-docker/hadoop/SNAPSHOT/
+```
+Replace `<your-hadoop-repo>` with the path where hadoop repo is cloned, and `<version>` with the correct version number of Hadoop you built.
+
+### 4. Build the Docker Images
+To build the required Docker images for ResourceManager and NodeManager, run the following command from the root of the `hadoop-yarn-docker` repository:
+```bash
+docker-compose build
+```
+
+### 5. Start the YARN Cluster
+After the images are built, bring up the necessary services (ResourceManager and NodeManager) using Docker Compose:
+```bash
+docker-compose up -d
+```
+This will start the YARN ResourceManager and NodeManager services in the background. You can check the status of your containers with:
+```bash
+docker-compose ps
+```
+
+### 6. Start the YARN Cluster
+You can now interact with the YARN ResourceManager via the web interface (typically available at `http://localhost:8088`) or using the YARN CLI commands within the container (`docker exec -it resourcemanager /bin/bash`). Note: Hadoop path: `/usr/local/hadoop` for looking at the logs, configured bin and confs.
+
+### 7. Stopping the Cluster
+To stop the cluster and remove the containers, run:
+```bash
+docker-compose down
+```
+This will stop and clean up all the services associated with the YARN cluster.
+
+## Notes
+- This setup is designed for testing and validation purposes in a containerized environment. 
+- For production use, consider running Hadoop in a distributed mode.
+- Modify the `docker-compose.yml` file to adjust memory and CPU resources based on your environment.
+- Ensure your Docker daemon has sufficient resources allocated (memory/CPU) for running both ResourceManager and NodeManager containers.
+
+## Troubleshooting
+- **Build Issues**: If the build fails, ensure that all dependencies (Maven, JDK) are correctly installed and that you're using compatible versions.
+- **Docker Issues**: If Docker services fail to start, verify that Docker and Docker Compose are installed and running properly.
+
+## License
+This project is licensed under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+version: '3'
+
+services:
+  resourcemanager:
+    build: .
+    container_name: resourcemanager
+    hostname: resourcemanager
+    networks:
+      - hadoop-net
+    volumes:
+      - ./hadoop/hadoop-conf:/usr/local/hadoop/etc/hadoop
+    command: >
+      bash -c "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64 && export HADOOP_HOME=/usr/local/hadoop/ && export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop && /usr/local/hadoop/bin/yarn --daemon start resourcemanager && tail -f /dev/null"
+    user: hadoop
+    privileged: true  # Grant the container elevated privileges
+
+    ports:
+      - "8088:8088"   # ResourceManager UI
+      - "50070:50070" # HDFS Namenode UI
+    environment:
+      - YARN_RESOURCEMANAGER_HOSTNAME=resourcemanager
+      - YARN_NODEMANAGER_INCLUDE_FILE=/usr/local/hadoop/etc/hadoop/includes
+      - YARN_NODEMANAGER_EXCLUDE_FILE=/usr/local/hadoop/etc/hadoop/excludes
+
+  nodemanager1:
+    build: .
+    container_name: nodemanager1
+    hostname: nodemanager1
+    networks:
+      - hadoop-net
+    volumes:
+      - ./hadoop/hadoop-conf:/usr/local/hadoop/etc/hadoop
+    command: >
+      su - hadoop -c "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64 && export HADOOP_HOME=/usr/local/hadoop/ && export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop && /usr/local/hadoop/bin/yarn --daemon start nodemanager && tail -f /dev/null"
+
+  nodemanager2:
+    build: .
+    container_name: nodemanager2
+    hostname: nodemanager2
+    networks:
+      - hadoop-net
+    volumes:
+      - ./hadoop/hadoop-conf:/usr/local/hadoop/etc/hadoop
+    command: >
+      su - hadoop -c "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64 && export HADOOP_HOME=/usr/local/hadoop/ && export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop && /usr/local/hadoop/bin/yarn --daemon start nodemanager && tail -f /dev/null"
+
+  nodemanager3:
+    build: .
+    container_name: nodemanager3
+    hostname: nodemanager3
+    networks:
+      - hadoop-net
+    volumes:
+      - ./hadoop/hadoop-conf:/usr/local/hadoop/etc/hadoop
+    command: >
+      su - hadoop -c "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64 && export HADOOP_HOME=/usr/local/hadoop/ && export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop && /usr/local/hadoop/bin/yarn --daemon start nodemanager && tail -f /dev/null"
+
+  nodemanager4:
+    build: .
+    container_name: nodemanager4
+    hostname: nodemanager4
+    networks:
+      - hadoop-net
+    volumes:
+      - ./hadoop/hadoop-conf:/usr/local/hadoop/etc/hadoop
+    command: >
+      su - hadoop -c "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64 && export HADOOP_HOME=/usr/local/hadoop/ && export HADOOP_CONF_DIR=/usr/local/hadoop/etc/hadoop && /usr/local/hadoop/bin/yarn --daemon start nodemanager && tail -f /dev/null"
+
+networks:
+  hadoop-net:
+    driver: bridge
+

--- a/hadoop/hadoop-conf/capacity-scheduler.xml
+++ b/hadoop/hadoop-conf/capacity-scheduler.xml
@@ -1,0 +1,121 @@
+<configuration>
+<property>
+    <name>yarn.scheduler.capacity.root.queues</name>
+    <value>default,public</value>
+    <description>
+      The queues at this level (root is the root queue).
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.default.capacity</name>
+    <value>99</value>
+    <description>Default queue target capacity.</description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.default.user-limit-factor</name>
+    <value>1</value>
+    <description>
+      Default queue user limit a percentage from 0.0 to 1.0.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.default.maximum-capacity</name>
+    <value>100</value>
+    <description>
+      The maximum capacity of the default queue.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.default.state</name>
+    <value>RUNNING</value>
+    <description>
+      The state of the default queue. State can be one of RUNNING or STOPPED.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.default.acl_submit_applications</name>
+    <value>*</value>
+    <description>
+      The ACL of who can submit jobs to the default queue.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.default.acl_administer_queue</name>
+    <value>*</value>
+    <description>
+      The ACL of who can administer jobs on the default queue.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.public.capacity</name>
+    <value>1</value>
+    <description>Public queue target capacity.</description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.public.user-limit-factor</name>
+    <value>1</value>
+    <description>
+      Public queue user limit a percentage from 0.0 to 1.0.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.public.maximum-capacity</name>
+    <value>100</value>
+    <description>
+      The maximum capacity of the public queue.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.public.state</name>
+    <value>RUNNING</value>
+    <description>
+      The state of the public queue. State can be one of RUNNING or STOPPED.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.public.acl_submit_applications</name>
+    <value>*</value>
+    <description>
+      The ACL of who can submit jobs to the public queue.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.public.acl_administer_queue</name>
+    <value>*</value>
+    <description>
+      The ACL of who can administer jobs on the public queue.
+    </description>
+</property>
+
+<property>
+     <name>yarn.scheduler.capacity.root.public.maximum-application-lifetime</name>
+     <value>-1</value>
+     <description>
+        Maximum lifetime of an application which is submitted to the public queue
+        in seconds. Any value less than or equal to zero will be considered as
+        disabled.
+     </description>
+</property>
+
+<property>
+     <name>yarn.scheduler.capacity.root.public.default-application-lifetime</name>
+     <value>-1</value>
+     <description>
+        Default lifetime of an application which is submitted to the public queue
+        in seconds. Any value less than or equal to zero will be considered as
+        disabled.
+     </description>
+</property>
+</configuration>

--- a/hadoop/hadoop-conf/core-site.xml
+++ b/hadoop/hadoop-conf/core-site.xml
@@ -1,0 +1,6 @@
+<configuration>
+  <property>
+    <name>fs.defaultFS</name>
+    <value>hdfs://resourcemanager:9000</value>
+  </property>
+</configuration>

--- a/hadoop/hadoop-conf/dcs/capacity-scheduler.xml
+++ b/hadoop/hadoop-conf/dcs/capacity-scheduler.xml
@@ -1,0 +1,121 @@
+<configuration>
+<property>
+    <name>yarn.scheduler.capacity.root.queues</name>
+    <value>default,public</value>
+    <description>
+      The queues at this level (root is the root queue).
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.default.capacity</name>
+    <value>99</value>
+    <description>Default queue target capacity.</description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.default.user-limit-factor</name>
+    <value>1</value>
+    <description>
+      Default queue user limit a percentage from 0.0 to 1.0.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.default.maximum-capacity</name>
+    <value>100</value>
+    <description>
+      The maximum capacity of the default queue.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.default.state</name>
+    <value>RUNNING</value>
+    <description>
+      The state of the default queue. State can be one of RUNNING or STOPPED.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.default.acl_submit_applications</name>
+    <value>*</value>
+    <description>
+      The ACL of who can submit jobs to the default queue.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.default.acl_administer_queue</name>
+    <value>*</value>
+    <description>
+      The ACL of who can administer jobs on the default queue.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.public.capacity</name>
+    <value>1</value>
+    <description>Public queue target capacity.</description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.public.user-limit-factor</name>
+    <value>1</value>
+    <description>
+      Public queue user limit a percentage from 0.0 to 1.0.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.public.maximum-capacity</name>
+    <value>100</value>
+    <description>
+      The maximum capacity of the public queue.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.public.state</name>
+    <value>RUNNING</value>
+    <description>
+      The state of the public queue. State can be one of RUNNING or STOPPED.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.public.acl_submit_applications</name>
+    <value>*</value>
+    <description>
+      The ACL of who can submit jobs to the public queue.
+    </description>
+</property>
+
+<property>
+    <name>yarn.scheduler.capacity.root.public.acl_administer_queue</name>
+    <value>*</value>
+    <description>
+      The ACL of who can administer jobs on the public queue.
+    </description>
+</property>
+
+<property>
+     <name>yarn.scheduler.capacity.root.public.maximum-application-lifetime</name>
+     <value>-1</value>
+     <description>
+        Maximum lifetime of an application which is submitted to the public queue
+        in seconds. Any value less than or equal to zero will be considered as
+        disabled.
+     </description>
+</property>
+
+<property>
+     <name>yarn.scheduler.capacity.root.public.default-application-lifetime</name>
+     <value>-1</value>
+     <description>
+        Default lifetime of an application which is submitted to the public queue
+        in seconds. Any value less than or equal to zero will be considered as
+        disabled.
+     </description>
+</property>
+</configuration>

--- a/hadoop/hadoop-conf/excludes
+++ b/hadoop/hadoop-conf/excludes
@@ -1,0 +1,1 @@
+nodemanager4

--- a/hadoop/hadoop-conf/hdfs-site.xml
+++ b/hadoop/hadoop-conf/hdfs-site.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <property>
+    <name>dfs.replication</name>
+    <value>3</value>
+  </property>
+  <property>
+    <name>dfs.namenode.name.dir</name>
+    <value>file:///usr/local/hadoop/hdfs/namenode</value>
+  </property>
+  <property>
+    <name>dfs.datanode.data.dir</name>
+    <value>file:///usr/local/hadoop/hdfs/datanode</value>
+  </property>
+</configuration>

--- a/hadoop/hadoop-conf/includes
+++ b/hadoop/hadoop-conf/includes
@@ -1,0 +1,4 @@
+nodemanager1
+nodemanager2
+nodemanager3
+nodemanager4

--- a/hadoop/hadoop-conf/log4j.properties
+++ b/hadoop/hadoop-conf/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%L) - %m%n

--- a/hadoop/hadoop-conf/mapred-site.xml
+++ b/hadoop/hadoop-conf/mapred-site.xml
@@ -1,0 +1,6 @@
+<configuration>
+  <property>
+    <name>mapreduce.framework.name</name>
+    <value>yarn</value>
+  </property>
+</configuration>

--- a/hadoop/hadoop-conf/workers
+++ b/hadoop/hadoop-conf/workers
@@ -1,0 +1,4 @@
+nodemanager1
+nodemanager2
+nodemanager3
+nodemanager4

--- a/hadoop/hadoop-conf/yarn-env.sh
+++ b/hadoop/hadoop-conf/yarn-env.sh
@@ -1,0 +1,3 @@
+export YARN_RESOURCEMANAGER_USER=hadoop
+export YARN_NODEMANAGER_USER=hadoop
+export YARN_PROXYSERVER_USER=hadoop

--- a/hadoop/hadoop-conf/yarn-site.xml
+++ b/hadoop/hadoop-conf/yarn-site.xml
@@ -1,0 +1,26 @@
+<configuration>
+  <property>
+    <name>yarn.scheduler.capacity.config.path</name>
+    <value>/usr/local/hadoop/etc/hadoop/dcs</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.hostname</name>
+    <value>resourcemanager</value>
+  </property>
+  <property>
+    <name>yarn.nodemanager.aux-services</name>
+    <value>mapreduce_shuffle</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.nodes.include-path</name>
+    <value>/usr/local/hadoop/etc/hadoop/includes</value>
+  </property>
+  <property>
+    <name>yarn.resourcemanager.nodes.exclude-path</name>
+    <value>/usr/local/hadoop/etc/hadoop/excludes</value>
+  </property>
+  <property>
+  <name>yarn.resourcemanager.enable-tracking-for-unregistered-nodes</name>
+  <value>true</value>
+</property>
+</configuration>


### PR DESCRIPTION
### Summary

This PR introduces a Docker-based setup for provisioning a YARN ResourceManager cluster, designed for quick validation and testing. The setup allows developers to easily build and run a YARN cluster locally for development, troubleshooting, and experimentation.

### Changes

- Docker Compose setup for ResourceManager and NodeManager services
- Instructions to build Hadoop from source and use the built snapshot for the Docker images
- Simplified commands for building Docker images and starting the YARN cluster
- Clear setup steps and troubleshooting guidance in the updated README

### How to Test

1. Clone the repository and build Hadoop from source.
2. Move the built snapshot to the Docker setup.
3. Run `docker-compose build && docker-compose up -d` to start the cluster.
4. Validate that the ResourceManager is running via the web UI at `http://localhost:8088`.

### Additional Notes

- This setup is primarily intended for development and testing.
- Review the README for detailed setup instructions.
